### PR TITLE
add disabled features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ categories = ["development-tools::testing"]
 [dependencies]
 lazy_static = "0.2"
 rand = "0.3"
+
+[features]
+disabled = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,7 @@ fn set(
 }
 
 #[macro_export]
+#[cfg(not(feature = "disabled"))]
 macro_rules! fail_point {
     ($name:expr, $e:expr) => {{
         let name = concat!(module_path!(), "::", $name);
@@ -349,6 +350,14 @@ macro_rules! fail_point {
             fail_point!($name, $e);
         }
     }};
+}
+
+#[macro_export]
+#[cfg(feature = "disabled")]
+macro_rules! fail_point {
+    ($name:expr, $e:expr) => {{}};
+    ($name:expr) => {{}};
+    ($name:expr, $cond:expr, $e:expr) => {{}};
 }
 
 #[cfg(test)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -151,8 +151,8 @@ fn test_freq_and_count() {
 
 #[test]
 fn test_condition() {
-    let f = |enabled| {
-        fail_point!("condition", enabled, |_| 2);
+    let f = |_enabled| {
+        fail_point!("condition", _enabled, |_| 2);
         0
     };
     assert_eq!(f(false), 0);


### PR DESCRIPTION
Usually failpoints is not expected to be enabled in release mode. So provide a feature to turn them off at compile time.