### PR TITLE
Simplify fail_point usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,8 @@ fn set(
 /// The full name of the `p1` fail point is `A::p1`, and `p2` is `A::my::p2`.
 ///
 /// `$e` is used to transform a string to the return type of outer function or closure.
-/// If you don't need to return early or a specified value, then you can use the `fail_point!($name)`.
+/// If you don't need to return early or a specified value, then you can use the
+/// `fail_point!($name)`.
 ///
 /// If you provide an additional condition `$cond`, then the condition will be evaluated
 /// before the fail point is actually checked.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,7 @@ fn set(
 /// The full name of the `p1` fail point is `A::p1`, and `p2` is `A::my::p2`.
 ///
 /// `$e` is used to transform a string to the return type of outer function or closure.
-/// If you don't need to return a customized value, then you can use the `fail_point!($name)`.
+/// If you don't need to return early or a specified value, then you can use the `fail_point!($name)`.
 ///
 /// If you provide an additional condition `$cond`, then the condition will be evaluated
 /// before the fail point is actually checked.
@@ -447,7 +447,9 @@ fn set(
 macro_rules! fail_point {
     ($name:expr) => {{
         let name = concat!(module_path!(), "::", $name);
-        $crate::eval(name, |_| {});
+        $crate::eval(name, |_| {
+            panic!("Return is not supported for the pattern fail_point!(\"...\")");
+        });
     }};
     ($name:expr, $e:expr) => {{
         let name = concat!(module_path!(), "::", $name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! extern crate fail;
 //!
 //! fn f1() {
-//!     fail_point!("example");
+//!     fail_point!("example", |_| {});
 //!     panic!();
 //! }
 //!
@@ -427,31 +427,33 @@ fn set(
 ///     fail_point!("p1");
 /// }
 ///
-/// mod M {
-///     fn f() {
+/// mod my {
+///     pub fn f() {
 ///         fail_point!("p2");
 ///     }
 /// }
-/// # fn main() {}
-/// ```
-/// The full name of the `p1` fail point is `A::p1`, and `p2` is `A::M::p2`.
 ///
-/// `$e` is used to transform a string to the return type of outer function or closure. If
-/// the return type is `()`, then you can use the `fail_point!($name)` shortcut.
+/// # fn main() { f(); my::f() }
+/// ```
+/// The full name of the `p1` fail point is `A::p1`, and `p2` is `A::my::p2`.
+///
+/// `$e` is used to transform a string to the return type of outer function or closure.
+/// If you don't need to return a customized value, then you can use the `fail_point!($name)`.
 ///
 /// If you provide an additional condition `$cond`, then the condition will be evaluated
 /// before the fail point is actually checked.
 #[macro_export]
 #[cfg(not(feature = "disabled"))]
 macro_rules! fail_point {
+    ($name:expr) => {{
+        let name = concat!(module_path!(), "::", $name);
+        $crate::eval(name, |_| {});
+    }};
     ($name:expr, $e:expr) => {{
         let name = concat!(module_path!(), "::", $name);
         if let Some(res) = $crate::eval(name, $e) {
             return res;
         }
-    }};
-    ($name:expr) => {{
-        fail_point!($name, |_| {});
     }};
     ($name:expr, $cond:expr, $e:expr) => {{
         if $cond {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -74,7 +74,7 @@ fn test_panic() {
 
 #[test]
 fn test_print() {
-        let f = || {
+    let f = || {
         fail_point!("print");
     };
     fail::cfg("tests::print", "print(msg)").unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -65,15 +65,21 @@ fn test_sleep() {
 #[test]
 #[should_panic]
 fn test_panic() {
+    let f = || {
+        fail_point!("panic");
+    };
     fail::cfg("tests::panic", "panic(msg)").unwrap();
-    fail_point!("panic");
+    f();
 }
 
 #[test]
 fn test_print() {
+        let f = || {
+        fail_point!("print");
+    };
     fail::cfg("tests::print", "print(msg)").unwrap();
     // TODO: checkout output.
-    fail_point!("print");
+    f();
 }
 
 #[test]
@@ -107,15 +113,19 @@ fn test_pause() {
 
 #[test]
 fn test_yield() {
+    let f = || {
+        fail_point!("yield");
+    };
     fail::cfg("tests::test", "yield").unwrap();
-    fail_point!("yield");
+    f();
 }
 
 #[test]
 fn test_delay() {
+    let f = || fail_point!("delay");
     let timer = Instant::now();
     fail::cfg("tests::delay", "delay(1000)").unwrap();
-    fail_point!("delay");
+    f();
     assert!(timer.elapsed() > Duration::from_millis(1000));
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -65,21 +65,15 @@ fn test_sleep() {
 #[test]
 #[should_panic]
 fn test_panic() {
-    let f = || {
-        fail_point!("panic");
-    };
     fail::cfg("tests::panic", "panic(msg)").unwrap();
-    f()
+    fail_point!("panic");
 }
 
 #[test]
 fn test_print() {
-    let f = || {
-        fail_point!("print");
-    };
     fail::cfg("tests::print", "print(msg)").unwrap();
     // TODO: checkout output.
-    f();
+    fail_point!("print");
 }
 
 #[test]
@@ -113,19 +107,15 @@ fn test_pause() {
 
 #[test]
 fn test_yield() {
-    let f = || {
-        fail_point!("yield");
-    };
     fail::cfg("tests::test", "yield").unwrap();
-    f();
+    fail_point!("yield");
 }
 
 #[test]
 fn test_delay() {
-    let f = || fail_point!("delay");
     let timer = Instant::now();
     fail::cfg("tests::delay", "delay(1000)").unwrap();
-    f();
+    fail_point!("delay");
     assert!(timer.elapsed() > Duration::from_millis(1000));
 }
 


### PR DESCRIPTION
For pattern ($name:expr), marco fail_point can be added to any
function, though the drawback is it does not support Retrun action.