### PR TITLE
Remove mod paths in failpoints name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A list of suggestions you should keep in mind:
  - **Enable** the no_fail feature in the release build.
  - Be careful about the complex combination.
  - Be careful about the fail point name and make sure it is self-described.
- - Fail points may have the same name, they take the same actions.
+ - Fail points might have the same name, and in this case, they take the same actions.
 
 ## To Do
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A list of suggestion you should keep in mind:
  - **Enable** `no_fail` feature in release build.
  - Be careful about complex combination.
  - Be careful about the fail point name, it should be self-described.
- - Fail points may have the same name, you should know what you doing when you choose the same name.
+ - Fail points may have the same name, a failure may occur unexpectedly.
 
 ## To DO
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fn function_conditional(enable: bool) {
 Trigger a fail point via the environment variable:
 
 ```
-$ FAILPOINTS=bar::foo=panic cargo run
+$ FAILPOINTS=foo=panic cargo run
 ```
 
 In unit tests:
@@ -55,7 +55,7 @@ In unit tests:
 ```
 #[test]
 fn test_foo() {
-    fail::cfg("bar::foo", "panic");
+    fail::cfg("foo", "panic");
     foo();
 }
 ```

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ fn test_foo() {
 
 ## Caveats
 
-Before putting any fail points you should carefully consider the consequences.
-A list of suggestion you should keep in mind:
+Before putting any fail points, you should carefully consider the consequences.
+A list of suggestions you should keep in mind:
 
- - **Enable** `no_fail` feature in release build.
- - Be careful about complex combination.
- - Be careful about the fail point name, it should be self-described.
+ - **Enable** the no_fail feature in the release build.
+ - Be careful about the complex combination.
+ - Be careful about the fail point name and make sure it is self-described.
  - Fail points may have the same name, they take the same actions.
 
-## To DO
+## To Do
 
 Triggering a fail point via the HTTP API is planned but not implemented yet.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ fn test_foo() {
 }
 ```
 
+## Caveats
+
+Before putting any fail points you should carefully consider the consequences.
+A list of suggestion you should keep in mind:
+
+ - **Enable** `no_fail` feature in release build.
+ - Be careful about complex combination.
+ - Be careful about the fail point name, it should be self-described.
+ - Fail points may have the same name, you should know what you doing when you choose the same name.
+
 ## To DO
 
 Triggering a fail point via the HTTP API is planned but not implemented yet.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A list of suggestion you should keep in mind:
  - **Enable** `no_fail` feature in release build.
  - Be careful about complex combination.
  - Be careful about the fail point name, it should be self-described.
- - Fail points may have the same name, a failure may occur unexpectedly.
+ - Fail points may have the same name, they take the same actions.
 
 ## To DO
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,7 @@ lazy_static! {
 /// The `FAILPOINTS` environment variable is used to configure all the fail points.
 /// The format of `FAILPOINTS` is `failpoint=actions;...`.
 ///
-/// `failpoint` is the fail point and its name.
+/// `failpoint` is the name of the fail point.
 /// For more information, see macro [`fail_point`](macro.fail_point.html) and
 /// [`cfg`](fn.cfg.html).
 pub fn setup() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! The above example defines a fail point named "example" and then configures it as `return`.
 //! So the `f1` function will return early and never panic. You can also configure it via the
-//! `FAILPOINTS=rust_out::example=return` environment variable. For more supported
+//! `FAILPOINTS=example=return` environment variable. For more supported
 //! configuration, see docs for macro [`fail_point`](macro.fail_point.html)
 //! and [`setup`](fn.setup.html).
 //!
@@ -314,9 +314,9 @@ lazy_static! {
 /// Set up the fail point system.
 ///
 /// The `FAILPOINTS` environment variable is used to configure all the fail points.
-/// The format of `FAILPOINTS` is `full_path_to_failpoint=actions;...`.
+/// The format of `FAILPOINTS` is `failpoint=actions;...`.
 ///
-/// `full_path_to_failpoint` is the full module path to the fail point and its name.
+/// `failpoint` is the fail point and its name.
 /// For more information, see macro [`fail_point`](macro.fail_point.html) and
 /// [`cfg`](fn.cfg.html).
 pub fn setup() {
@@ -433,8 +433,7 @@ fn set(
 
 /// The only entry to define a fail point.
 ///
-/// When a fail point is defined, it's referenced via the full module path and name in the
-/// format of `crate::module::submodule::fail_point_name`. For example, library A defines
+/// When a fail point is defined, it's referenced via the name. For example, library A defines
 /// a fail point in lib.rs as follows:
 ///
 /// ```rust
@@ -453,7 +452,6 @@ fn set(
 ///
 /// # fn main() { f(); my::f() }
 /// ```
-/// The full name of the `p1` fail point is `A::p1`, and `p2` is `A::my::p2`.
 ///
 /// `$e` is used to transform a string to the return type of outer function or closure.
 /// If you don't need to return early or a specified value, then you can use the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! fn main() {
 //!    fail::setup();
-//!    fail::cfg("rust_out::example", "return").unwrap();
+//!    fail::cfg("example", "return").unwrap();
 //!    f1();
 //!    fail::teardown();
 //! }
@@ -465,14 +465,12 @@ fn set(
 #[cfg(not(feature = "no_fail"))]
 macro_rules! fail_point {
     ($name:expr) => {{
-        let name = concat!(module_path!(), "::", $name);
-        $crate::eval(name, |_| {
+        $crate::eval($name, |_| {
             panic!("Return is not supported for the pattern fail_point!(\"...\")");
         });
     }};
     ($name:expr, $e:expr) => {{
-        let name = concat!(module_path!(), "::", $name);
-        if let Some(res) = $crate::eval(name, $e) {
+        if let Some(res) = $crate::eval($name, $e) {
             return res;
         }
     }};
@@ -683,7 +681,7 @@ mod tests {
         };
         env::set_var(
             "FAILPOINTS",
-            "fail::tests::setup_and_teardown1=return;fail::tests::setup_and_teardown2=pause;",
+            "setup_and_teardown1=return;setup_and_teardown2=pause;",
         );
         setup();
         assert_eq!(f1(), 1);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -192,7 +192,8 @@ fn test_condition() {
 
 #[test]
 fn test_list() {
-    assert!(!fail::list().contains(&("list".to_string(), "off".to_string())));
+    assert!(!fail::list()
+        .contains(&("list".to_string(), "off".to_string())));
     fail::cfg("list", "off").unwrap();
     assert!(fail::list().contains(&("list".to_string(), "off".to_string())));
     fail::cfg("list", "return").unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -29,7 +29,7 @@ fn test_off() {
     };
     assert_eq!(f(), 0);
 
-    fail::cfg("tests::off", "off").unwrap();
+    fail::cfg("off", "off").unwrap();
     assert_eq!(f(), 0);
 }
 
@@ -43,10 +43,10 @@ fn test_return() {
     };
     assert_eq!(f(), 0);
 
-    fail::cfg("tests::return", "return(1000)").unwrap();
+    fail::cfg("return", "return(1000)").unwrap();
     assert_eq!(f(), 1000);
 
-    fail::cfg("tests::return", "return").unwrap();
+    fail::cfg("return", "return").unwrap();
     assert_eq!(f(), 2);
 }
 
@@ -60,7 +60,7 @@ fn test_sleep() {
     assert!(timer.elapsed() < Duration::from_millis(1000));
 
     let timer = Instant::now();
-    fail::cfg("tests::sleep", "sleep(1000)").unwrap();
+    fail::cfg("sleep", "sleep(1000)").unwrap();
     f();
     assert!(timer.elapsed() > Duration::from_millis(1000));
 }
@@ -71,7 +71,7 @@ fn test_panic() {
     let f = || {
         fail_point!("panic");
     };
-    fail::cfg("tests::panic", "panic(msg)").unwrap();
+    fail::cfg("panic", "panic(msg)").unwrap();
     f();
 }
 
@@ -98,15 +98,15 @@ fn test_print() {
     let f = || {
         fail_point!("print");
     };
-    fail::cfg("tests::print", "print(msg)").unwrap();
+    fail::cfg("print", "print(msg)").unwrap();
     f();
     let msg = buffer.lock().unwrap().pop().unwrap();
     assert_eq!(msg, "msg");
 
-    fail::cfg("tests::print", "print").unwrap();
+    fail::cfg("print", "print").unwrap();
     f();
     let msg = buffer.lock().unwrap().pop().unwrap();
-    assert_eq!(msg, "failpoint tests::print executed.");
+    assert_eq!(msg, "failpoint print executed.");
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn test_pause() {
     };
     f();
 
-    fail::cfg("tests::pause", "pause").unwrap();
+    fail::cfg("pause", "pause").unwrap();
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
         // pause
@@ -128,11 +128,11 @@ fn test_pause() {
     });
 
     assert!(rx.recv_timeout(Duration::from_millis(500)).is_err());
-    fail::cfg("tests::pause", "pause").unwrap();
+    fail::cfg("pause", "pause").unwrap();
     rx.recv_timeout(Duration::from_millis(500)).unwrap();
 
     assert!(rx.recv_timeout(Duration::from_millis(500)).is_err());
-    fail::remove("tests::pause");
+    fail::remove("pause");
     rx.recv_timeout(Duration::from_millis(500)).unwrap();
 
     rx.recv_timeout(Duration::from_millis(500)).unwrap();
@@ -143,7 +143,7 @@ fn test_yield() {
     let f = || {
         fail_point!("yield");
     };
-    fail::cfg("tests::test", "yield").unwrap();
+    fail::cfg("test", "yield").unwrap();
     f();
 }
 
@@ -151,7 +151,7 @@ fn test_yield() {
 fn test_delay() {
     let f = || fail_point!("delay");
     let timer = Instant::now();
-    fail::cfg("tests::delay", "delay(1000)").unwrap();
+    fail::cfg("delay", "delay(1000)").unwrap();
     f();
     assert!(timer.elapsed() > Duration::from_millis(1000));
 }
@@ -165,7 +165,7 @@ fn test_freq_and_count() {
         0
     };
     fail::cfg(
-        "tests::freq_and_count",
+        "freq_and_count",
         "50%50*return(1)->50%50*return(-1)->50*return",
     ).unwrap();
     let mut sum = 0;
@@ -184,7 +184,7 @@ fn test_condition() {
     };
     assert_eq!(f(false), 0);
 
-    fail::cfg("tests::condition", "return").unwrap();
+    fail::cfg("condition", "return").unwrap();
     assert_eq!(f(false), 0);
 
     assert_eq!(f(true), 2);
@@ -192,9 +192,9 @@ fn test_condition() {
 
 #[test]
 fn test_list() {
-    assert!(!fail::list().contains(&("tests::list".to_string(), "off".to_string())));
-    fail::cfg("tests::list", "off").unwrap();
-    assert!(fail::list().contains(&("tests::list".to_string(), "off".to_string())));
-    fail::cfg("tests::list", "return").unwrap();
-    assert!(fail::list().contains(&("tests::list".to_string(), "return".to_string())));
+    assert!(!fail::list().contains(&("list".to_string(), "off".to_string())));
+    fail::cfg("list", "off").unwrap();
+    assert!(fail::list().contains(&("list".to_string(), "off".to_string())));
+    fail::cfg("list", "return").unwrap();
+    assert!(fail::list().contains(&("list".to_string(), "return".to_string())));
 }


### PR DESCRIPTION
Currently, module paths are added to fail points name automatically.
So the actual name differs from the declaration and changes whenever we move the module that contains fail points.

This PR remove mod paths.