### PR TITLE
Use rustup provided clippy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   allow_failures:
     - rust: nightly
 script:
-  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo install -f clippy && cargo clippy; fi
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then rustup component add clippy-preview && cargo clippy; fi
   - export RUSTFLAGS=-Dwarnings
   - cargo build
   - cargo test --all


### PR DESCRIPTION
Also see: https://internals.rust-lang.org/t/clippy-is-available-as-a-rustup-component/7967

Move the clippy we use from being installed by `cargo` to being installed by `rustup`. If you find strange problems with clippy after they are merged you will need to do: `cargo uninstall clippy && cargo uninstall clippy-lints && rustup self update`

This is because the old versions of rustup don't know that clippy is managed, so they give errors like `subcommand clippy does not exist`.

### Reasons for doing this:

Currently the clippy version must be managed separate from the Rust nightly. Using Rustup will allow each of our projects to depend on their own clippy versions and help avoid some toolchain related problems.

### The PRs:

* https://github.com/pingcap/raft-rs/pull/95
* https://github.com/pingcap/rust-prometheus/pull/186
* https://github.com/pingcap/grpc-rs/pull/208
* https://github.com/pingcap/fail-rs/pull/13
* https://github.com/pingcap/tikv/pull/3335