### PR TITLE
Expand the documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["failpoints", "fail"]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/vksd5ifajog5gbiu/branch/master?svg=true)](https://ci.appveyor.com/project/busyjay/fail-rs/branch/master)
 [![Crates.io](https://img.shields.io/crates/v/fail.svg?maxAge=2592000)](https://crates.io/crates/fail)
 
-[Documentation](https://docs.rs/fail)
+[Documentation](https://docs.rs/fail).
 
 A fail point implementation for Rust.
 
-Fail point is a code point that are used to inject errors by users at runtime.
+Fail points are code instrumentations that allow errors and other behavior to be injected dynamically at runtime, primarily for testing purposes. Fail points are flexible and can be configured to exhibit a variety of behavior, including panics, early returns, and sleeping. They can be controlled both programmatically and via the environment, and can be triggered conditionally and probabilistically.
+
 This crate is inspired by FreeBSD's [failpoints](https://freebsd.org/cgi/man.cgi?query=fail).
 
 ## Usage
@@ -20,56 +21,52 @@ First, add this to your `Cargo.toml`:
 fail = "0.2"
 ```
 
-Next, add the following code to your crate:
+Now you can import the `fail_point!` macro from the `fail` crate and use it to inject dynamic failures.
+
+As an example, here's a simple program that uses a fail point to simulate an I/O panic:
 
 ```rust
 #[macro_use]
 extern crate fail;
-```
 
-Define the fail points:
-
-```rust
-fn function_return_tuple() {
-    fail_point!("name1");
+fn do_fallible_work() {
+    fail_point!("read-dir");
+    let _dir: Vec<_> = std::fs::read_dir(".").unwrap().collect();
+    // ... do some work on the directory ...
 }
 
-fn function_return_others() -> u64 {
-    fail_point!("name2", |r| r.map_or(2, |e| e.parse().unwrap()));
-    0
-}
-
-fn function_conditional(enable: bool) {
-    fail_point!("name3", enable, |_| {});
+fn main() {
+    fail::setup();
+    do_fallible_work();
+    fail::teardown();
+    println!("done");
 }
 ```
 
-Trigger a fail point via the environment variable:
+Here, the program calls `unwrap` on the result of `read_dir`, a function that returns a `Result`. In other words, this particular program expects this call to `read_dir` to always succeed. And in practice it almost always will, which makes the behavior of this program when `read_dir` fails difficult to test. By instrumenting the program with a fail point we can pretend that `read_dir` failed, causing the subsequent `unwrap` to panic, and allowing us to observe the program's behavior under failure conditions.
 
-```bash
-$ FAILPOINTS=foo=panic cargo run
+When the program is run normally it just prints "done":
+
+```sh
+$ cargo run
+    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
+     Running `target/debug/failpointtest`
+done
 ```
 
-In unit tests:
+But now, by setting the `FAILPOINTS` variable we can see what happens if the `read_dir` fails:
 
-```rust
-#[test]
-fn test_foo() {
-    fail::cfg("foo", "panic");
-    foo();
-}
+```
+FAILPOINTS=read-dir=panic cargo run
+    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
+     Running `target/debug/failpointtest`
+thread 'main' panicked at 'failpoint read-dir panic', /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/fail-0.2.0/src/lib.rs:286:25
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
 ```
 
-## Caveats
+For further information see the [API documentation](https://docs.rs/fail).
 
-Before putting any fail points, you should carefully consider the consequences.
-A list of suggestions you should keep in mind:
 
- - **Enable** the no_fail feature in the release build.
- - Be careful about the complex combination.
- - Be careful about the fail point name and make sure it is self-described.
- - Fail points might have the same name, and in this case, they take the same actions.
-
-## To Do
+## TODO
 
 Triggering a fail point via the HTTP API is planned but not implemented yet.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ impl FromStr for Action {
         if let Some(second) = second {
             remain = first;
             if !second.ends_with(')') {
-                return Err("parentheses not match".to_owned());
+                return Err("parentheses do not match".to_owned());
             }
             args = Some(&second[..second.len() - 1]);
         }
@@ -335,7 +335,9 @@ pub fn setup() {
         let (name, order) = partition(cfg, '=');
         match order {
             None => panic!("invalid failpoint: {:?}", cfg),
-            Some(order) => set(&mut registry, name.to_owned(), order).unwrap(),
+            Some(order) => if let Err(e) = set(&mut registry, name.to_owned(), order) {
+                panic!("unable to configure failpoint \"{}\": {}", name, e);
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,7 +463,7 @@ fn set(
 macro_rules! fail_point {
     ($name:expr) => {{
         $crate::eval($name, |_| {
-            panic!("Return is not supported for the pattern fail_point!(\"...\")");
+            panic!("Return is not supported for the fail point \"{}\"", $name);
         });
     }};
     ($name:expr, $e:expr) => {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@
 //!     do_fallible_work();
 //!     fail::teardown();
 //! }
+//! # fn main() { }
 //! ```
 //!
 //! So this is a test that sets up the fail point to panic, and the test is
@@ -167,6 +168,7 @@
 //!     fail::cfg("read-dir", "panic").unwrap();
 //!     do_fallible_work();
 //! }
+//! # fn main() { }
 //! ```
 //!
 //! With this arrangement, any test that calls `setup` and holds the resulting
@@ -257,6 +259,8 @@
 //! Here's a variation that does so:
 //!
 //! ```rust
+//! # #[macro_use] extern crate fail;
+//! # use std::io;
 //! fn do_fallible_work() -> io::Result<()> {
 //!     fail_point!("read-dir", |_| {
 //!         Err(io::Error::new(io::ErrorKind::PermissionDenied, "error"))
@@ -297,6 +301,8 @@
 //! into the return value:
 //!
 //! ```rust
+//! # #[macro_use] extern crate fail;
+//! # use std::io;
 //! fn do_fallible_work() -> io::Result<()> {
 //!     fail_point!("read-dir", |err| {
 //!         let err = err.unwrap_or("error".to_string());
@@ -755,6 +761,7 @@ fn set(
 /// 1. A basic fail point:
 ///
 /// ```rust
+/// # #[macro_use] extern crate fail;
 /// fn function_return_unit() {
 ///     fail_point!("fail-point-1");
 /// }
@@ -766,6 +773,7 @@ fn set(
 /// 2. A fail point that may return early:
 ///
 /// ```rust
+/// # #[macro_use] extern crate fail;
 /// fn function_return_value() -> u64 {
 ///     fail_point!("fail-point-2", |r| r.map_or(2, |e| e.parse().unwrap()));
 ///     0
@@ -784,6 +792,7 @@ fn set(
 /// 3. A fail point with conditional execution:
 ///
 /// ```rust
+/// # #[macro_use] extern crate fail;
 /// fn function_conditional(enable: bool) {
 ///     fail_point!("fail-point-3", enable, |_| {});
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@
 //!  - Carefully consider complex, concurrent, non-deterministic combinations of
 //!    fail points. Put test cases exercising fail points into their own test
 //!    crate and protect each test case with a mutex guard.
-//!  - Use self-describing fail point names. 
+//!  - Use self-describing fail point names.
 //!  - Fail points might have the same name, in which case they take the
 //!    same actions. Be careful about duplicating fail point names, either within
 //!    a single crate, or across multiple crates.
@@ -640,8 +640,10 @@ pub fn setup() {
         let (name, order) = partition(cfg, '=');
         match order {
             None => panic!("invalid failpoint: {:?}", cfg),
-            Some(order) => if let Err(e) = set(&mut registry, name.to_owned(), order) {
-                panic!("unable to configure failpoint \"{}\": {}", name, e);
+            Some(order) => {
+                if let Err(e) = set(&mut registry, name.to_owned(), order) {
+                    panic!("unable to configure failpoint \"{}\": {}", name, e);
+                }
             }
         }
     }
@@ -901,7 +903,8 @@ mod tests {
         log::set_logger(|e| {
             e.set(LogLevelFilter::Info);
             Box::new(collector)
-        }).unwrap();
+        })
+        .unwrap();
 
         let point = FailPoint::new();
         point.set_actions("", vec![Action::new(Task::Print(None), 1.0, None)]);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -92,7 +92,8 @@ fn test_print() {
     log::set_logger(|e| {
         e.set(LogLevelFilter::Info);
         Box::new(collector)
-    }).unwrap();
+    })
+    .unwrap();
 
     let f = || {
         fail_point!("print");
@@ -165,7 +166,8 @@ fn test_freq_and_count() {
     fail::cfg(
         "freq_and_count",
         "50%50*return(1)->50%50*return(-1)->50*return",
-    ).unwrap();
+    )
+    .unwrap();
     let mut sum = 0;
     for _ in 0..5000 {
         let res = f();


### PR DESCRIPTION
This is a big overhaul of the documentation for this crate, both the readme and the API docs. The major change here is to use the crate-level documentation to gradually introduce the major features of fail points, but almost all of the docs are touched. The README now introduces the basic use of fail points, then defers to the API docs.

It includes two minor fixes for error messages generated by the crate, both of which are reflected in the examples in the docs.

Finally it includes a minor version bump, so if this is merged it can be published.

PTAL @BusyJay cc @Hoverbear 
cc @queenypingcap lots of API docs