### PR TITLE
*: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ description = "Failpoints for rust."
 categories = ["development-tools::testing"]
 
 [dependencies]
-log = "0.3"
-lazy_static = "0.2"
-rand = "0.3"
+log = { version = "0.4", features = ["std"] }
+lazy_static = "1.2"
+rand = "0.6"
 
 [features]
 no_fail = []


### PR DESCRIPTION
* `log` 0.3 → 0.4 (thanks to semver tricks, this won't cause much incompatibility with TiKV's use of `log 0.3`. see https://docs.rs/log/0.4.6/log/#version-compatibility)
* `lazy_static` 0.2 → 1.2 
* `rand` 0.3 → 0.6


