### PR TITLE
Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/pingcap/fail-rs"
 documentation = "https://docs.rs/fail"
 description = "Failpoints for rust."
 categories = ["development-tools::testing"]
+edition = "2018"
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["failpoints", "fail"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -738,7 +738,10 @@ fn set(
 ) -> Result<(), String> {
     let actions_str = actions;
     // `actions` are in the format of `failpoint[->failpoint...]`.
-    let actions = actions.split("->").map(Action::from_str).collect::<Result<_, _>>()?;
+    let actions = actions
+        .split("->")
+        .map(Action::from_str)
+        .collect::<Result<_, _>>()?;
     // Please note that we can't figure out whether there is a failpoint named `name`,
     // so we may insert a failpoint that doesn't exist at all.
     let p = registry

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,12 +499,12 @@ impl FromStr for Action {
         let task = match remain {
             "off" => Task::Off,
             "return" => Task::Return(args.map(str::to_owned)),
-            "sleep" => Task::Sleep(r#try!(parse_timeout())),
+            "sleep" => Task::Sleep(parse_timeout()?),
             "panic" => Task::Panic(args.map(str::to_owned)),
             "print" => Task::Print(args.map(str::to_owned)),
             "pause" => Task::Pause,
             "yield" => Task::Yield,
-            "delay" => Task::Delay(r#try!(parse_timeout())),
+            "delay" => Task::Delay(parse_timeout()?),
             _ => return Err(format!("unrecognized command {:?}", remain)),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,12 +499,12 @@ impl FromStr for Action {
         let task = match remain {
             "off" => Task::Off,
             "return" => Task::Return(args.map(str::to_owned)),
-            "sleep" => Task::Sleep(try!(parse_timeout())),
+            "sleep" => Task::Sleep(r#try!(parse_timeout())),
             "panic" => Task::Panic(args.map(str::to_owned)),
             "print" => Task::Print(args.map(str::to_owned)),
             "pause" => Task::Pause,
             "yield" => Task::Yield,
-            "delay" => Task::Delay(try!(parse_timeout())),
+            "delay" => Task::Delay(r#try!(parse_timeout())),
             _ => return Err(format!("unrecognized command {:?}", remain)),
         };
 
@@ -738,7 +738,7 @@ fn set(
 ) -> Result<(), String> {
     let actions_str = actions;
     // `actions` are in the format of `failpoint[->failpoint...]`.
-    let actions = try!(actions.split("->").map(Action::from_str).collect());
+    let actions = r#try!(actions.split("->").map(Action::from_str).collect());
     // Please note that we can't figure out whether there is a failpoint named `name`,
     // so we may insert a failpoint that doesn't exist at all.
     let p = registry

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -738,7 +738,7 @@ fn set(
 ) -> Result<(), String> {
     let actions_str = actions;
     // `actions` are in the format of `failpoint[->failpoint...]`.
-    let actions = r#try!(actions.split("->").map(Action::from_str).collect());
+    let actions = actions.split("->").map(Action::from_str).collect::<Result<_, _>>()?;
     // Please note that we can't figure out whether there is a failpoint named `name`,
     // so we may insert a failpoint that doesn't exist at all.
     let p = registry


### PR DESCRIPTION
Fixes https://github.com/pingcap/fail-rs/issues/21

I've tested this changed against the tikv/failpoints test suite and everything looks ok.

This doesn't make any idiomatic changes, like removing 'extern crates'. I'll follow up with additional issues there.

This bumps the version to 0.3.