### PR TITLE
change some code  style to rust 2018 edition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,9 +269,9 @@ use std::sync::{Arc, Condvar, Mutex, RwLock, TryLockError};
 use std::time::{Duration, Instant};
 use std::{env, thread};
 
-use rand::Rng;
 use lazy_static::lazy_static;
 use log::info;
+use rand::Rng;
 
 /// Supported tasks.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,12 +261,6 @@
 
 #![deny(missing_docs, missing_debug_implementations)]
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-extern crate rand;
-
 use std::collections::HashMap;
 use std::env::VarError;
 use std::str::FromStr;
@@ -276,6 +270,8 @@ use std::time::{Duration, Instant};
 use std::{env, thread};
 
 use rand::Rng;
+use lazy_static::lazy_static;
+use log::info;
 
 /// Supported tasks.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,7 +460,7 @@ impl FailPoint {
     fn eval(&self, name: &str) -> Option<Option<String>> {
         let task = {
             let actions = self.actions.read().unwrap();
-            match actions.iter().filter_map(|a| a.get_task()).next() {
+            match actions.iter().filter_map(Action::get_task).next() {
                 Some(Task::Pause) => {
                     let mut guard = self.pause.lock().unwrap();
                     *guard = true;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::sync::*;
 use std::time::*;
 use std::*;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -11,13 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
-extern crate fail;
-extern crate log;
 
 use std::sync::*;
 use std::time::*;
 use std::*;
+
+use fail::fail_point;
 
 #[test]
 fn test_off() {


### PR DESCRIPTION
In the early commit ec69d82. I see it turn on the 2018 edition.
So I changes some code styles.